### PR TITLE
Allow jetboard to be used in no jetboard zones

### DIFF
--- a/goal_src/jak2/engine/game/settings.gc
+++ b/goal_src/jak2/engine/game/settings.gc
@@ -411,7 +411,8 @@
     (('calm)
      (set! (-> this attack) (not arg1))
      (set! (-> this gun) (not arg1))
-     (set! (-> this board) (not arg1))
+     ;; og:jetboard Removed board toggle while in calm mode
+     ;; (set! (-> this board) (not arg1))
      (set! (-> this jump) (not arg1))
      (set! (-> this double-jump) (not arg1))
      (set! (-> this darkjak) (not arg1))


### PR DESCRIPTION
Only control for this was calm mode. Checked all zones in the game & jak is not forced off.

Though I found a crash in onin's tent caused by want-sound loading 'onin1 as well as a palace cable crash near the rotating spikes caused by want-sound loading 'palcab3

I'm not sure how to fix these two crashes.