### PR TITLE
Revert Jetboard speed changes

### DIFF
--- a/goal_src/jak2/engine/target/board/target-board.gc
+++ b/goal_src/jak2/engine/target/board/target-board.gc
@@ -129,7 +129,7 @@
     :turnvv 131072.0
     :tiltv 131072.0
     :tiltvv 2621440.0
-    :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+    :transv-max 143360.0
     :target-speed 102400.0
     :seek0 0.5
     :seek90 0.5
@@ -246,7 +246,7 @@
                            :turnvv 131072.0
                            :tiltv 16384.0
                            :tiltvv 131072.0
-                           :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+                           :transv-max 143360.0
                            :target-speed 102400.0
                            :seek0 0.8
                            :seek90 0.8
@@ -280,7 +280,7 @@
                             :turnvv 524288.0
                             :tiltv 32768.0
                             :tiltvv 131072.0
-                            :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+                            :transv-max 143360.0
                             :target-speed 102400.0
                             :fric 0.2
                             :nonlin-fric-dist 1.0
@@ -309,7 +309,7 @@
     :turnvv 32768.0
     :tiltv 32768.0
     :tiltvv 131072.0
-    :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+    :transv-max 143360.0
     :target-speed 102400.0
     :nonlin-fric-dist 1.0
     :slip-factor 1.0
@@ -387,7 +387,7 @@
                                  :name 'jump
                                  :tiltv 65536.0
                                  :tiltvv 262144.0
-                                 :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+                                 :transv-max 143360.0
                                  :target-speed 102400.0
                                  :seek180 0.8
                                  :fric 0.2
@@ -426,7 +426,7 @@
                                 :turnvv 524288.0
                                 :tiltv 16384.0
                                 :tiltvv 131072.0
-                                :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+                                :transv-max 143360.0
                                 :target-speed 102400.0
                                 :fric 0.2
                                 :nonlin-fric-dist 1.0
@@ -452,7 +452,7 @@
                                :turnv 524288.0
                                :tiltv 131072.0
                                :tiltvv 2621440.0
-                               :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+                               :transv-max 143360.0
                                :target-speed 102400.0
                                :seek0 0.5
                                :seek90 0.5
@@ -486,7 +486,7 @@
                             :turnvv 131072.0
                             :tiltv 131072.0
                             :tiltvv 262144.0
-                            :transv-max 409600.0 ;; OG:Jetboard/No OoJ Changed Max Jetboard Speed to 100 meters
+                            :transv-max 143360.0
                             :target-speed 40960.0
                             :seek0 0.5
                             :seek90 0.5


### PR DESCRIPTION
Tested to make sure walls were still breakable.

In certain missions maybe we can/should adjust jetboard speed but 3X it globally over the whole game made the jetboard tough to control sometimes and made it possible to circumvent certain areas/sections by building up massive speed.

Not opposed to changing this in some areas/missions etc. But it should be done there instead of globally.